### PR TITLE
Updated Clipster specific logger calls to use `exc_info` when a stack…

### DIFF
--- a/code/clipster.py
+++ b/code/clipster.py
@@ -130,7 +130,7 @@ class Clipster:
         @self.bot.event
         async def on_command_error(ctx, exception):
             ## Something weird happened, log it!
-            LOGGER.exception("Unhandled exception in during command execution", exception)
+            LOGGER.exception("Unhandled exception in during command execution", exc_info=exception)
             await self.database_manager.store(ctx, valid=False)
 
     ## Properties

--- a/modules/clips/clip_file_manager.py
+++ b/modules/clips/clip_file_manager.py
@@ -69,11 +69,11 @@ class ClipFileManager:
 
                 clip = Clip(name, path, **kwargs)
                 clips.append(clip)
-            except FileNotFoundError as e:
+            except FileNotFoundError:
                 LOGGER.warn(f"Unable to find clip associate with '{name}'. Skipping...")
                 continue
             except Exception as e:
-                LOGGER.warn(f"Error loading clip '{clip_raw['name']}'. Skipping...", e)
+                LOGGER.warn(f"Error loading clip '{name}'. Skipping...", exc_info=e)
                 continue
 
         return sorted(clips, key=lambda clip: clip.name)
@@ -122,7 +122,7 @@ class ClipFileManager:
 
                 return clip_group
             except Exception as e:
-                LOGGER.warning(f"Error loading clip group '{clip_group_name}' from '{path}''. Skipping...", e)
+                LOGGER.warning(f"Error loading clip group '{clip_group_name}' from '{path}''. Skipping...", exc_info=e)
                 return None
 
 

--- a/modules/clips/clips.py
+++ b/modules/clips/clips.py
@@ -173,7 +173,7 @@ class Clips(DiscoverableCog):
 
                 await self.audio_player_cog._play_audio_via_server_state(server_state, clip_path, callback)
         except Exception as e:
-            LOGGER.exception("Exception during channel sign-off", e)
+            LOGGER.exception("Exception during channel sign-off", exc_info=e)
             await callback()
 
 
@@ -192,7 +192,7 @@ class Clips(DiscoverableCog):
                 try:
                     self.clips[clip.name] = clip
                 except Exception as e:
-                    LOGGER.warning("Skipping...", e)
+                    LOGGER.warning("Skipping...", exc_info=e)
                 else:
                     counter += 1
 
@@ -224,7 +224,7 @@ class Clips(DiscoverableCog):
             await self.audio_player_cog.play_audio(clip.path, author, target_member or author, interaction)
 
         except NoVoiceChannelAvailableException as e:
-            LOGGER.error("No voice channel available", e)
+            LOGGER.error("No voice channel available", exc_info=e)
             if (e.target_member.id == author.id):
                 return InvokedCommand(False, e, f"Sorry <@{author.id}>, you're not in a voice channel.")
             else:
@@ -242,7 +242,7 @@ class Clips(DiscoverableCog):
             return InvokedCommand(False, e, f"Sorry <@{author.id}>, I'm not able to {' or '.join(error_values)} that channel. Check the permissions and try again later.")
 
         except FileNotFoundError as e:
-            LOGGER.error("FileNotFound when invoking `play_audio`", e)
+            LOGGER.error("FileNotFound when invoking `play_audio`", exc_info=e)
             return InvokedCommand(False, e, f"Sorry <@{author.id}>, I can't say that right now.")
 
         return InvokedCommand(True)


### PR DESCRIPTION
…trace is necessary